### PR TITLE
Pruitt/refresh secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,7 @@ go 1.16
 require (
 	github.com/aws/aws-lambda-go v1.23.0
 	github.com/aws/aws-sdk-go v1.38.27
+	github.com/fatih/color v1.7.0
+	github.com/mitchellh/copystructure v1.2.0
 	github.com/spf13/cobra v1.1.3
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -113,11 +114,15 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
@@ -125,6 +130,8 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -242,6 +249,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/cmd/ship.go
+++ b/src/cmd/ship.go
@@ -34,12 +34,21 @@ func init() {
 
 	shipCmd.Flags().BoolVarP(&noWait, "no-wait", "w", false, "Deploy and exit; Do not wait for service to reach stable state")
 
+	shipCmd.Flags().BoolVar(&deploymentOptions.RefreshSecrets, "refresh-secrets", false, "Replace task defintion secrets with all ssm paramters with a prefix matching the 'secrets-prefix'")
+
+	shipCmd.Flags().BoolVar(&deploymentOptions.DryRun, "dry-run", false, "Show changes without modifying resources.")
+
+	shipCmd.Flags().StringVarP(&deploymentOptions.SecretsPrefix, "secrets-prefix", "p", "", "The ssm parameter store prefix to pull secrets from. Default: \"/<environment>/<application>/\"")
 }
 
 var shipCmd = &cobra.Command{
 	Use:   "ship",
 	Short: "Ship an application to ECS",
 	Run: func(cmd *cobra.Command, args []string) {
+
+		if deploymentOptions.SecretsPrefix == "" {
+			deploymentOptions.SecretsPrefix = fmt.Sprintf("/%s/%s", deploymentOptions.Environment, deploymentOptions.Application)
+		}
 
 		fmt.Printf("Deploying %s@%s to %s\n", deploymentOptions.Application, deploymentOptions.Version, deploymentOptions.Environment)
 		results, err := deployer.PerformDeployment(deploymentOptions)

--- a/src/deployer/deployer.go
+++ b/src/deployer/deployer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ssm"
+
+	"github.com/mitchellh/copystructure"
 )
 
 var (
@@ -28,9 +31,11 @@ var (
 func PerformDeployment(depOpts DeploymentOptions) (s string, err error) {
 	var deploymentResults DeploymentResults
 	// Set the desired application version
-	err = setDesiredVersion(depOpts)
-	if err != nil {
-		return s, err
+	if !depOpts.DryRun {
+		err = setDesiredVersion(depOpts)
+		if err != nil {
+			return s, err
+		}
 	}
 
 	var svc *ecs.ECS
@@ -68,18 +73,32 @@ func PerformDeployment(depOpts DeploymentOptions) (s string, err error) {
 		return s, err
 	}
 
+	// Deep copy to preserve original container definitions for diff
+	copyContainerDefs, err := copystructure.Copy(dtdo.TaskDefinition.ContainerDefinitions)
+	if err != nil {
+		fmt.Printf("Error performing deep copy of container definitions: %v", err)
+		os.Exit(1)
+	}
+	desiredContainerDefinitions, ok := copyContainerDefs.([]*ecs.ContainerDefinition)
+	if !ok {
+		fmt.Printf("Error converting interface to ecs.ContainerDefinition: %v", err)
+		os.Exit(1)
+	}
+
 	// Update only first container definition
-	repoAndVersion := strings.Split(*dtdo.TaskDefinition.ContainerDefinitions[0].Image, ":")
+	repoAndVersion := strings.Split(*desiredContainerDefinitions[0].Image, ":")
 	if len(repoAndVersion) == 1 {
 		repoAndVersion = append(repoAndVersion, depOpts.Version)
 	} else {
 		repoAndVersion[1] = depOpts.Version
 	}
-	*dtdo.TaskDefinition.ContainerDefinitions[0].Image = strings.Join(repoAndVersion, ":")
+
+	// Update only the first contianer image version - ignore sidecar containers assuming they are defined second, third, and so on.
+	*desiredContainerDefinitions[0].Image = strings.Join(repoAndVersion, ":")
 
 	// Register new task definition
 	rtdi := &ecs.RegisterTaskDefinitionInput{
-		ContainerDefinitions:    dtdo.TaskDefinition.ContainerDefinitions,
+		ContainerDefinitions:    desiredContainerDefinitions,
 		Cpu:                     dtdo.TaskDefinition.Cpu,
 		ExecutionRoleArn:        dtdo.TaskDefinition.ExecutionRoleArn,
 		Family:                  dtdo.TaskDefinition.Family,
@@ -90,24 +109,106 @@ func PerformDeployment(depOpts DeploymentOptions) (s string, err error) {
 		Volumes:                 dtdo.TaskDefinition.Volumes,
 		RequiresCompatibilities: dtdo.TaskDefinition.RequiresCompatibilities,
 	}
+
+	if depOpts.RefreshSecrets {
+		var ssmClient *ssm.SSM
+		if depOpts.Role != "" {
+			creds := stscreds.NewCredentials(sess, depOpts.Role)
+			ssmClient = ssm.New(sess, &aws.Config{Credentials: creds})
+		} else {
+			ssmClient = ssm.New(sess)
+		}
+
+		pageNum := 0
+		containerSecrets := []*ecs.Secret{}
+		err := ssmClient.GetParametersByPathPages(&ssm.GetParametersByPathInput{
+			Path: aws.String(depOpts.SecretsPrefix),
+		},
+			func(page *ssm.GetParametersByPathOutput, lastPage bool) bool {
+				pageNum++
+				for _, v := range page.Parameters {
+
+					ss := strings.Split(*v.Name, "/")
+					s := ss[len(ss)-1]
+
+					secret := &ecs.Secret{
+						Name:      aws.String(s),
+						ValueFrom: v.ARN,
+					}
+					containerSecrets = append(containerSecrets, secret)
+				}
+				return pageNum <= 100
+			})
+
+		if err != nil {
+			fmt.Printf("Error refreshing ssm params: %v", err)
+			os.Exit(1)
+		}
+
+		desiredContainerDefinitions[0].Secrets = containerSecrets
+
+	}
+
+	// Diff task image version
+	diff := NewDiff("container", *dtdo.TaskDefinition.ContainerDefinitions[0].Name)
+	for index, currentContainerDef := range dtdo.TaskDefinition.ContainerDefinitions {
+		diff.AddChange("image", *currentContainerDef.Image, *desiredContainerDefinitions[index].Image)
+
+		// Diff task secrets
+		for _, x := range currentContainerDef.Secrets {
+			found := false
+			for _, y := range desiredContainerDefinitions[index].Secrets {
+				// TODO diff secrets
+				if *x.Name == *y.Name {
+					diff.AddChange(*x.Name, *x.ValueFrom, *y.ValueFrom)
+					found = true
+				}
+			}
+
+			if !found {
+				diff.AddChange(*x.Name, *x.ValueFrom, "")
+			}
+		}
+
+		for _, y := range desiredContainerDefinitions[index].Secrets {
+			found := false
+			for _, x := range currentContainerDef.Secrets {
+				if *x.Name == *y.Name {
+					found = true
+				}
+			}
+			if !found {
+				diff.AddChange(*y.Name, "", *y.ValueFrom)
+			}
+		}
+
+		if len(diff.changes) > 0 {
+			fmt.Println(diff)
+		}
+	}
+
+	if depOpts.DryRun {
+		os.Exit(0)
+	}
+
 	rtdo, err := svc.RegisterTaskDefinition(rtdi)
 	if err != nil {
 		return s, err
 	}
 	// Update the service with the new task definition
 	usi := &ecs.UpdateServiceInput{
-		Cluster:                       dso.Services[0].ClusterArn,
-		DeploymentConfiguration:       dso.Services[0].DeploymentConfiguration,
-		DesiredCount:                  dso.Services[0].DesiredCount,
-		ForceNewDeployment:            aws.Bool(true),
-		NetworkConfiguration:          dso.Services[0].NetworkConfiguration,
-		PlatformVersion:               dso.Services[0].PlatformVersion,
-		Service:                       dso.Services[0].ServiceArn,
-		TaskDefinition:                rtdo.TaskDefinition.TaskDefinitionArn,
+		Cluster:                 dso.Services[0].ClusterArn,
+		DeploymentConfiguration: dso.Services[0].DeploymentConfiguration,
+		DesiredCount:            dso.Services[0].DesiredCount,
+		ForceNewDeployment:      aws.Bool(true),
+		NetworkConfiguration:    dso.Services[0].NetworkConfiguration,
+		PlatformVersion:         dso.Services[0].PlatformVersion,
+		Service:                 dso.Services[0].ServiceArn,
+		TaskDefinition:          rtdo.TaskDefinition.TaskDefinitionArn,
 	}
 	// If HealthCheckGracePeriodSeconds == 0 (Default), assume that the previous definition did not include a health check.
-	if  *dso.Services[0].HealthCheckGracePeriodSeconds != 0 {
-    usi.HealthCheckGracePeriodSeconds = dso.Services[0].HealthCheckGracePeriodSeconds
+	if *dso.Services[0].HealthCheckGracePeriodSeconds != 0 {
+		usi.HealthCheckGracePeriodSeconds = dso.Services[0].HealthCheckGracePeriodSeconds
 	}
 
 	uso, err := svc.UpdateService(usi)

--- a/src/deployer/diff.go
+++ b/src/deployer/diff.go
@@ -1,0 +1,41 @@
+package deployer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// Diff represents data to be added and removed
+type Diff struct {
+	resource string
+	name     string
+	changes  []string
+}
+
+func (diff Diff) String() string {
+	fmt.Println(fmt.Sprintf("\n%s \"%s\" { ", diff.resource, diff.name))
+	return strings.Join(diff.changes, "\n") + "\n}\n"
+}
+
+func NewDiff(resource string, name string) Diff {
+	return Diff{
+		resource: resource,
+		name:     name,
+		changes:  []string{},
+	}
+}
+
+func (diff *Diff) AddChange(key, x, y string) {
+	if x == y {
+		diff.changes = append(diff.changes, color.WhiteString(fmt.Sprintf(" \t%s =\t%s", key, y)))
+	} else if x == "" {
+		diff.changes = append(diff.changes, color.GreenString(fmt.Sprintf("+\t%s =\t%s", key, y)))
+	} else if y == "" {
+		// Removing from x
+		diff.changes = append(diff.changes, color.RedString(fmt.Sprintf("-\t%s =\t%s", key, x)))
+	} else {
+		diff.changes = append(diff.changes, color.YellowString(fmt.Sprintf("~\t%s =\t%s  -->  %s", key, x, y)))
+	}
+}

--- a/src/deployer/types.go
+++ b/src/deployer/types.go
@@ -14,6 +14,12 @@ type DeploymentOptions struct {
 	Role string `json:"Role"`
 	// MaxAttempts is the Number of attempts to wait for service to become stable, with subsequent 15 sec pause.
 	MaxAttempts int `json:"MaxAttempts"`
+	// RefreshSecrets will update all container definition secrets to include ssm parameters that exists with the prefix "/<cluster>/service/*"
+	RefreshSecrets bool `json:"RefreshSecrets"`
+	// The ssm parameter store prefix to pull secrets from. Default: "/<cluster>/service/*"
+	SecretsPrefix string `json:"SecretsPrefix"`
+	// DryRun will preview changes
+	DryRun bool `json:"DryRun"`
 }
 
 // DeploymentResults maintain the depyments latest results


### PR DESCRIPTION
This pr adds three flags shown below.

```
      --dry-run                 Show changes without modifying resources.
      --refresh-secrets         Replace task defintion secrets with all ssm paramters with a prefix matching the 'secrets-prefix'
  -p, --secrets-prefix string   The ssm parameter store prefix to pull secrets from. Default: "/<environment>/<application>/"
```

The goal is to add the ability to add or delete task definition secrets during the deployment based on an ssm parameter prefix. All parameters with the given `secrets-prefix` will be included in the new task definition. This eliminates the need for IaC to manage the app configuration and enables the use of optional environment variables without infrastructure code changes. For example, changing the log level of an application from a defaulted value to DEBUG.